### PR TITLE
chore(deps): bump https://github.com/ci-cd-jenkins-x-kubernetes-packt/hello-3-5-replace.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -9,3 +9,4 @@ Dependency | Sources | Version | Mismatched versions
 [ci-cd-jenkins-x-kubernetes-packt/hello-3-2-specify](https://github.com/ci-cd-jenkins-x-kubernetes-packt/hello-3-2-specify.git) |  | []() | 
 [ci-cd-jenkins-x-kubernetes-packt/test-1](https://github.com/ci-cd-jenkins-x-kubernetes-packt/test-1.git) |  | []() | 
 [ci-cd-jenkins-x-kubernetes-packt/hello-3-5-audit](https://github.com/ci-cd-jenkins-x-kubernetes-packt/hello-3-5-audit.git) |  | []() | 
+[ci-cd-jenkins-x-kubernetes-packt/hello-3-5-replace](https://github.com/ci-cd-jenkins-x-kubernetes-packt/hello-3-5-replace.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -41,3 +41,9 @@ dependencies:
   url: https://github.com/ci-cd-jenkins-x-kubernetes-packt/hello-3-5-audit.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: ci-cd-jenkins-x-kubernetes-packt
+  repo: hello-3-5-replace
+  url: https://github.com/ci-cd-jenkins-x-kubernetes-packt/hello-3-5-replace.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/ci-cd-jenkins-x-kubernetes-packt-hello-3-5-replace-sr.yaml
+++ b/repositories/templates/ci-cd-jenkins-x-kubernetes-packt-hello-3-5-replace-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: ci-cd-jenkins-x-kubernetes-packt
+    provider: github
+    repository: hello-3-5-replace
+  name: ci-cd-jenkins-x-kubernetes-packt-hello-3-5-replace
+spec:
+  description: Imported application for ci-cd-jenkins-x-kubernetes-packt/hello-3-5-replace
+  httpCloneURL: https://github.com/ci-cd-jenkins-x-kubernetes-packt/hello-3-5-replace.git
+  org: ci-cd-jenkins-x-kubernetes-packt
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: hello-3-5-replace
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/ci-cd-jenkins-x-kubernetes-packt/hello-3-5-replace.git


### PR DESCRIPTION
Update [ci-cd-jenkins-x-kubernetes-packt/hello-3-5-replace](https://github.com/ci-cd-jenkins-x-kubernetes-packt/hello-3-5-replace.git) 

Command run was `jx import hello-3-5-replace --git-public`